### PR TITLE
Bundle LICENSE and NOTICE in published artifacts

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,45 @@
+Kepko
+Copyright 2025 Yasan Ghaffarian
+
+This product includes color palettes derived from the following third-party
+projects, each licensed under the MIT License:
+
+================================================================================
+Solarized
+================================================================================
+Copyright (c) 2011 Ethan Schoonover
+https://github.com/altercation/solarized
+
+================================================================================
+Catppuccin
+================================================================================
+Copyright (c) 2021 Catppuccin
+https://github.com/catppuccin/catppuccin
+
+================================================================================
+Gruvbox
+================================================================================
+Copyright (c) 2018 Pavel Pertsev
+https://github.com/morhetz/gruvbox
+
+================================================================================
+MIT License
+================================================================================
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,9 +1,12 @@
 Kepko
 Copyright 2025 Yasan Ghaffarian
 
-This product includes color palettes derived from the following third-party
-projects, each licensed under the MIT License:
+Kepko itself is licensed under the Apache License, Version 2.0.
+See the root LICENSE file for the full Apache-2.0 license text.
 
+This NOTICE file also includes attribution and license information for
+color palettes derived from the following third-party projects, each licensed
+under the MIT License:
 ================================================================================
 Solarized
 ================================================================================

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,5 +124,14 @@ subprojects {
         apply(plugin = "org.jetbrains.dokka")
         apply(plugin = "org.jetbrains.kotlinx.kover")
         configurePublishing()
+
+        tasks.withType<Jar>().configureEach {
+            from(rootProject.file("LICENSE")) {
+                into("META-INF")
+            }
+            from(rootProject.file("NOTICE")) {
+                into("META-INF")
+            }
+        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added comprehensive licensing attribution document containing Apache 2.0 licensing information and third-party attribution details.
  * Updated build configuration to automatically include license files in distributed JAR artifacts for improved licensing transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->